### PR TITLE
Remove hardcoded $VERSION from TeX::Encode::BibTex

### DIFF
--- a/lib/TeX/Encode/BibTeX.pm
+++ b/lib/TeX/Encode/BibTeX.pm
@@ -11,8 +11,6 @@ use TeX::Encode;
 
 our @ISA = qw(Encode::Encoding);
 
-our $VERSION = '1.2';
-
 __PACKAGE__->Define(qw(BibTeX bibtex));
 
 # encode($self, $string [,$check])


### PR DESCRIPTION
The $VERSION line is nowadays autogenerated, resulting
in two clashing version declarations that cause a warning
on usage.

Bug-Debian: https://bugs.debian.org/877094